### PR TITLE
Runner script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ profile.cov
 **/yarn-error.log
 /ofac_blacklist.json
 /blacklist.json
+scripts/kurtosis/network_params_tmp.json

--- a/scripts/dind/Dockerfile.kurtosis_dind
+++ b/scripts/dind/Dockerfile.kurtosis_dind
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/devcontainers/base:bullseye
+
+# Get Go
+RUN apt install git curl tar && \
+    curl https://dl.google.com/go/go1.21.3.linux-amd64.tar.gz -o go.tar.gz && \
+    tar -C /usr/local -xzf go.tar.gz && \
+    rm go.tar.gz
+
+# Set up Go environment variables
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+
+# Install Kurtosis
+RUN echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | tee /etc/apt/sources.list.d/kurtosis.list
+RUN sudo apt update && \
+    sudo apt install kurtosis-cli
+
+WORKDIR /geth
+COPY ../ .

--- a/scripts/emulate_network.go
+++ b/scripts/emulate_network.go
@@ -20,7 +20,7 @@ func build(imageTag string, buildDir string, buildDockerfilePath string) {
 	runCommand(cmd)
 }
 
-func update_config(imageTag string, imageArgs string, filename ...string) {
+func update_config(imageTag string, imageArgs string, kurtosisNetworkScriptFolder string, filename ...string) {
 	// Determine the filename. If not provided, default to "network_params.json".
 	var file string
 	if len(filename) > 0 {
@@ -53,7 +53,8 @@ func update_config(imageTag string, imageArgs string, filename ...string) {
 			}
 
 			// Check if the participant is the one with "el_client_type": "geth"
-			if p["el_client_type"] == "geth" {
+			if p["el_client_type"] == "REPLACE_WITH_BUILDER" {
+				p["el_client_type"] = "geth"
 				// Modify the participant entry as needed
 				p["el_client_image"] = imageTag
 
@@ -71,6 +72,8 @@ func update_config(imageTag string, imageArgs string, filename ...string) {
 				} else {
 					fmt.Println("Error: el_extra_params is not an array of strings")
 				}
+
+				fmt.Println("Detected and updated BUILDER config: ", p)
 				break // Exit the loop once the participant is found and updated
 			}
 		}
@@ -90,7 +93,7 @@ func update_config(imageTag string, imageArgs string, filename ...string) {
 	fmt.Println(string(modifiedContent))
 
 	// Save the modified content back to the file
-	//err = ioutil.WriteFile("network_params.json", modifiedContent, os.ModePerm)
+	err = ioutil.WriteFile(kurtosisNetworkScriptFolder+"/network_params_tmp.json", modifiedContent, os.ModePerm)
 	if err != nil {
 		fmt.Println("Error writing the modified content to the file:", err)
 	}
@@ -105,7 +108,7 @@ func run(imageTag, imageArgs, enclaveName string, maxSteps int, kurtosisPath, ku
 		"kurtosis_path":           kurtosisPath,
 		"kurtosis_network_config": kurtosisNetworkScriptFolder,
 	}*/
-	update_config(imageTag, imageArgs, kurtosisNetConfigPath)
+	update_config(imageTag, imageArgs, kurtosisNetworkScriptFolder, kurtosisNetConfigPath)
 
 	cmd := fmt.Sprintf("%s run --enclave %s %s", kurtosisPath, enclaveName, kurtosisNetworkScriptFolder)
 	runCommand(cmd)

--- a/scripts/emulate_network.go
+++ b/scripts/emulate_network.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"runtime"
+	"sync"
+)
+
+func build(imageTag string, buildDir string, buildDockerfilePath string) {
+	cmd := "docker build" +
+		" -t " + imageTag +
+		" -f " + buildDockerfilePath +
+		" " + buildDir
+	runCommand(cmd)
+}
+
+func update_config(imageTag string, imageArgs string, filename ...string) {
+	// Determine the filename. If not provided, default to "network_params.json".
+	var file string
+	if len(filename) > 0 {
+		file = filename[0]
+	} else {
+		file = "network_params.json"
+	}
+
+	// Read the file
+	fileContent, err := ioutil.ReadFile(file)
+	if err != nil {
+		fmt.Println("Error reading the file:", err)
+		return
+	}
+
+	var data map[string]interface{}
+	err = json.Unmarshal(fileContent, &data)
+	if err != nil {
+		fmt.Println("Error unmarshalling the JSON:", err)
+		return
+	}
+
+	// Navigate to the participants array
+	if participants, ok := data["participants"].([]interface{}); ok {
+		for _, participant := range participants {
+			p, ok := participant.(map[string]interface{})
+			if !ok {
+				fmt.Println("Error casting participant to map")
+				continue
+			}
+
+			// Check if the participant is the one with "el_client_type": "geth"
+			if p["el_client_type"] == "geth" {
+				// Modify the participant entry as needed
+				p["el_client_image"] = imageTag
+
+				if extraParamsInterface, ok := p["el_extra_params"].([]interface{}); ok {
+					var extraParams []string
+					for _, paramInterface := range extraParamsInterface {
+						if param, ok := paramInterface.(string); ok {
+							extraParams = append(extraParams, param)
+						} else {
+							fmt.Println("Error: el_extra_params contains a non-string value")
+						}
+					}
+					extraParams = append(extraParams, imageArgs)
+					p["el_extra_params"] = extraParams
+				} else {
+					fmt.Println("Error: el_extra_params is not an array of strings")
+				}
+				break // Exit the loop once the participant is found and updated
+			}
+		}
+	} else {
+		fmt.Println("Participants field not found or not an array")
+		return
+	}
+
+	// Marshal the map back to JSON
+	modifiedContent, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		fmt.Println("Error marshalling the map back to JSON:", err)
+		return
+	}
+
+	// Print out the resulting string
+	fmt.Println(string(modifiedContent))
+
+	// Save the modified content back to the file
+	//err = ioutil.WriteFile("network_params.json", modifiedContent, os.ModePerm)
+	if err != nil {
+		fmt.Println("Error writing the modified content to the file:", err)
+	}
+}
+
+func run(imageTag, imageArgs, enclaveName string, maxSteps int, kurtosisPath, kurtosisNetworkScriptFolder string, kurtosisNetConfigPath string) {
+	/*	params := map[string]interface{}{
+		"image_tag":               imageTag,
+		"image_args":              imageArgs,
+		"enclave_name":            enclaveName,
+		"max_steps":               maxSteps,
+		"kurtosis_path":           kurtosisPath,
+		"kurtosis_network_config": kurtosisNetworkScriptFolder,
+	}*/
+	update_config(imageTag, imageArgs, kurtosisNetConfigPath)
+
+	cmd := fmt.Sprintf("%s run --enclave %s %s", kurtosisPath, enclaveName, kurtosisNetworkScriptFolder)
+	runCommand(cmd)
+}
+
+func stop(kurtosisPath, enclaveName string) {
+	if enclaveName == "" {
+		fmt.Println("Error: enclave name must be specified.")
+		cmd := fmt.Sprintf("%s enclave ls", kurtosisPath)
+		runCommand(cmd)
+		return
+	}
+	cmd := fmt.Sprintf("%s enclave rm -f %s", kurtosisPath, enclaveName)
+	runCommand(cmd)
+}
+
+func runCommand(cmd string) {
+	var command *exec.Cmd
+	if runtime.GOOS == "windows" {
+		fmt.Println("Running on Windows:", cmd)
+		command = exec.Command("cmd", "/C", cmd)
+	} else {
+		fmt.Println("Running:", cmd)
+		command = exec.Command("sh", "-c", cmd)
+	}
+
+	stdoutPipe, err := command.StdoutPipe()
+	if err != nil {
+		fmt.Printf("Error obtaining stdout: %v\n", err)
+		return
+	}
+
+	stderrPipe, err := command.StderrPipe()
+	if err != nil {
+		fmt.Printf("Error obtaining stderr: %v\n", err)
+		return
+	}
+
+	err = command.Start()
+	if err != nil {
+		fmt.Printf("Command start failed: %v\n", err)
+		return
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		scanner := bufio.NewScanner(stdoutPipe)
+		for scanner.Scan() {
+			fmt.Println(scanner.Text())
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		scanner := bufio.NewScanner(stderrPipe)
+		for scanner.Scan() {
+			fmt.Println(scanner.Text())
+		}
+	}()
+
+	wg.Wait()
+
+	err = command.Wait()
+	if err != nil {
+		fmt.Printf("Command execution failed: %v\n", err)
+	}
+}
+
+func help() {
+	fmt.Println(`Emulate Network script
+Available commands:
+- build
+  - -t : Image tag (optional, default: "flashbots/builder:dev")
+  - -d : Image Build directory (optional, default: "..")
+  - -f : Build dockerfile path (optional, default: "../Dockerfile")
+- run
+  - -t : Image tag (optional, default: "flashbots/builder:dev")
+  - -n : Enclave name (optional, default: "explorer")
+  - -a : Additional builder arguments (optional)
+  - -s : Max steps (optional, default: -1)
+  - -k : Kurtosis path (optional, default: "kurtosis")
+  - -c : Kurtosis network config (optional, default: "./kurtosis")
+- stop
+  - -k : Kurtosis path (optional, default: "kurtosis")
+  - -n : Enclave name (required)
+`)
+}
+
+func main() {
+	flagSet := flag.NewFlagSet("", flag.ExitOnError)
+	imageTag := flagSet.String("t", "flashbots/builder:dev", "Image tag for build or run.")
+	enclaveName := flagSet.String("n", "explorer", "Enclave name for run or stop.")
+	kurtosisPath := flagSet.String("k", "kurtosis", "Kurtosis path for run or stop.")
+
+	if len(os.Args) < 2 {
+		fmt.Println("Please provide a command. Available commands are: build, run, stop.")
+		return
+	}
+
+	switch os.Args[1] {
+	case "build":
+		buildDir := flagSet.String("d", "..", "Build directory.")
+		buildDockerfilePath := flagSet.String("f", "../Dockerfile", "Build dockerfile path.")
+		flagSet.Parse(os.Args[2:])
+		build(*imageTag, *buildDir, *buildDockerfilePath)
+	case "run":
+		imageArgs := flagSet.String("a", "", "Image arguments for run.")
+		maxSteps := flagSet.Int("s", -1, "Max steps for run.")
+		kurtosisNetworkConfigScriptFolder := flagSet.String("f", "./kurtosis", "Kurtosis network config for run.")
+		kurtosisNetConfigPath := flagSet.String("c", "./kurtosis/network_params.json", "Kurtosis network params "+
+			"configuration path. Note that run command modifies it with provided imageTag and imageArgs.")
+		flagSet.Parse(os.Args[2:])
+		run(*imageTag, *imageArgs, *enclaveName, *maxSteps, *kurtosisPath, *kurtosisNetworkConfigScriptFolder, *kurtosisNetConfigPath)
+	case "stop":
+		flagSet.Parse(os.Args[2:])
+		stop(*kurtosisPath, *enclaveName)
+	case "help":
+		help()
+	default:
+		fmt.Println("Invalid command. Available commands are: build, run, stop.")
+	}
+}

--- a/scripts/kurtosis/data/grafana/dashboard.json
+++ b/scripts/kurtosis/data/grafana/dashboard.json
@@ -1,0 +1,3592 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": {
+                    "type": "datasource",
+                    "uid": "grafana"
+                },
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "target": {
+                    "limit": 100,
+                    "matchAny": false,
+                    "tags": [],
+                    "type": "dashboard"
+                },
+                "type": "dashboard"
+            }
+        ]
+    },
+    "description": "Geth metrics overview dashboard.",
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "gnetId": 14053,
+    "graphTooltip": 1,
+    "id": 3,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 122,
+            "panels": [],
+            "title": "Builder",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 1
+            },
+            "id": 124,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(miner_bundle_simulate_success_count{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "hide": false,
+                    "legendFormat": "success",
+                    "range": true,
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(miner_bundle_simulate_failed_count{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "legendFormat": "fail",
+                    "range": true,
+                    "refId": "B"
+                }
+            ],
+            "title": "Bundle Simulations",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 1
+            },
+            "id": 125,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(miner_block_build_count{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "hide": false,
+                    "legendFormat": "build",
+                    "range": true,
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(miner_block_merge_count{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "hide": false,
+                    "legendFormat": "merge",
+                    "range": true,
+                    "refId": "C"
+                }
+            ],
+            "title": "Blocks",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "Gwei",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "locale"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 1
+            },
+            "id": 126,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "rate(miner_block_profit_gauge{client_name=~\"$client_name\", service=~\"$instance\"}[$rate]) / 1000000000",
+                    "hide": false,
+                    "legendFormat": "build",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Profit",
+            "type": "timeseries"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 7
+            },
+            "id": 128,
+            "panels": [],
+            "title": "Simulation",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 8
+            },
+            "id": 130,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(rpc_duration_eth_callBundle_success_count{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "legendFormat": "success",
+                    "range": true,
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(rpc_duration_eth_callBundle_failure_count{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "hide": false,
+                    "legendFormat": "failure",
+                    "range": true,
+                    "refId": "B"
+                }
+            ],
+            "title": "eth_callBundle calls",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "ms",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 8
+            },
+            "id": 132,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rpc_duration_eth_callBundle_success{quantile=\"$quantile\", client_name=~\"$client_name\", service=~\"$instance\"} / 1000",
+                    "legendFormat": "{{service}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Durations of successful eth_callBundle calls",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "ms",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 8
+            },
+            "id": 133,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rpc_duration_eth_callBundle_failure{quantile=\"$quantile\", client_name=~\"$client_name\", service=~\"$instance\"} / 1000",
+                    "legendFormat": "{{service}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Durations of failed eth_callBundle calls",
+            "type": "timeseries"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 14
+            },
+            "id": 135,
+            "panels": [],
+            "title": "Validation",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 15
+            },
+            "id": 136,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(rpc_duration_flashbots_validateBuilderSubmissionV2_success_count{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "legendFormat": "success",
+                    "range": true,
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(rpc_duration_flashbots_validateBuilderSubmissionV2_failure_count{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "hide": false,
+                    "legendFormat": "failure",
+                    "range": true,
+                    "refId": "B"
+                }
+            ],
+            "title": "flashbots_validateBuilderSubmissionV2 calls",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "ms",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 15
+            },
+            "id": 137,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rpc_duration_flashbots_validateBuilderSubmissionV2_success{quantile=\"$quantile\", client_name=~\"$client_name\", service=~\"$instance\"}/1000",
+                    "legendFormat": "{{service}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Durations of successful eth_callBundle calls",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "ms",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 15
+            },
+            "id": 138,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rpc_duration_flashbots_validateBuilderSubmissionV2_success{quantile=\"$quantile\", client_name=~\"$client_name\", service=~\"$instance\"} / 1000",
+                    "legendFormat": "{{service}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Durations of failed flashbots_validateBuilderSubmissionV2 calls",
+            "type": "timeseries"
+        },
+        {
+            "collapsed": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "06O6Z894k"
+            },
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 21
+            },
+            "id": 82,
+            "panels": [],
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "06O6Z894k"
+                    },
+                    "refId": "A"
+                }
+            ],
+            "title": "System",
+            "type": "row"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 22
+            },
+            "hiddenSeries": false,
+            "id": 106,
+            "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.4.7",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "system_cpu_sysload{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "system",
+                    "range": true,
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "system_cpu_syswait{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "iowait",
+                    "range": true,
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "system_cpu_procload{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "geth",
+                    "range": true,
+                    "refId": "C"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "CPU",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "percent",
+                    "logBase": 1,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 22
+            },
+            "hiddenSeries": false,
+            "id": 86,
+            "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.4.7",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(system_memory_allocs{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "alloc",
+                    "range": true,
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "system_memory_used{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "used",
+                    "range": true,
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "system_memory_held{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "held",
+                    "range": true,
+                    "refId": "C"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Memory",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 22
+            },
+            "hiddenSeries": false,
+            "id": 85,
+            "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.4.7",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(system_disk_readbytes{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "read",
+                    "range": true,
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(system_disk_writebytes{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "write",
+                    "range": true,
+                    "refId": "B"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Disk",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "Bps",
+                    "logBase": 1,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        },
+        {
+            "collapsed": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "06O6Z894k"
+            },
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 28
+            },
+            "id": 75,
+            "panels": [],
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "06O6Z894k"
+                    },
+                    "refId": "A"
+                }
+            ],
+            "title": "Network",
+            "type": "row"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 29
+            },
+            "hiddenSeries": false,
+            "id": 96,
+            "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.4.7",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(p2p_ingress{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "ingress",
+                    "range": true,
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(p2p_egress{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "egress",
+                    "range": true,
+                    "refId": "C"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Traffic",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "Bps",
+                    "logBase": 1,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 29
+            },
+            "hiddenSeries": false,
+            "id": 77,
+            "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.4.7",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "p2p_peers{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "peers",
+                    "range": true,
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(p2p_dials{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "dials",
+                    "range": true,
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(p2p_serves{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "serves",
+                    "range": true,
+                    "refId": "C"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Peers",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:93",
+                    "format": "none",
+                    "logBase": 1,
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:94",
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        },
+        {
+            "collapsed": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "06O6Z894k"
+            },
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 35
+            },
+            "id": 4,
+            "panels": [],
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "06O6Z894k"
+                    },
+                    "refId": "A"
+                }
+            ],
+            "title": "Blockchain",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "rgb(252, 252, 252)"
+                            }
+                        ]
+                    },
+                    "unit": "locale"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 2,
+                "w": 3,
+                "x": 0,
+                "y": 36
+            },
+            "id": 108,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.4.7",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "max(chain_head_header{client_name=~\"$client_name\", service=~\"$instance\"})",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{service}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Latest header",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "stepAfter",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green"
+                            }
+                        ]
+                    },
+                    "unit": "locale"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 9,
+                "x": 3,
+                "y": 36
+            },
+            "id": 110,
+            "links": [],
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "9.4.7",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "chain_head_header{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "header",
+                    "range": true,
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "chain_head_receipt{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "receipt",
+                    "range": true,
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "chain_head_block{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "block",
+                    "range": true,
+                    "refId": "C"
+                }
+            ],
+            "title": "Chain head",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "rgb(255, 255, 255)"
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 2,
+                "w": 3,
+                "x": 12,
+                "y": 36
+            },
+            "id": 113,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.4.7",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "txpool_pending{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{service}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Executable transactions",
+            "type": "stat"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 6,
+                "w": 9,
+                "x": 15,
+                "y": 36
+            },
+            "hiddenSeries": false,
+            "id": 116,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.4.7",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "txpool_pending{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "executable",
+                    "range": true,
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "txpool_queued{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "gapped",
+                    "range": true,
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "txpool_local{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "local",
+                    "range": true,
+                    "refId": "C"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Transaction pool",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "rgb(255, 255, 255)"
+                            }
+                        ]
+                    },
+                    "unit": "locale"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 2,
+                "w": 3,
+                "x": 0,
+                "y": 38
+            },
+            "id": 111,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.4.7",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "max(chain_head_receipt{client_name=~\"$client_name\", service=~\"$instance\"})",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{service}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Latest receipt",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "rgb(255, 255, 255)"
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 2,
+                "w": 3,
+                "x": 12,
+                "y": 38
+            },
+            "id": 114,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.4.7",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "txpool_queued{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{service}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Gapped transactions",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "rgb(255, 255, 255)"
+                            }
+                        ]
+                    },
+                    "unit": "locale"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 2,
+                "w": 3,
+                "x": 0,
+                "y": 40
+            },
+            "id": 109,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.4.7",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "max(chain_head_block{client_name=~\"$client_name\", service=~\"$instance\"})",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{service}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Latest block",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "rgb(255, 255, 255)"
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 2,
+                "w": 3,
+                "x": 12,
+                "y": 40
+            },
+            "id": 115,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.4.7",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "txpool_local{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{service}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Local transactions",
+            "type": "stat"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 11,
+                "w": 24,
+                "x": 0,
+                "y": 42
+            },
+            "hiddenSeries": false,
+            "id": 112,
+            "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": true,
+                "min": true,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.4.7",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "chain_execution{quantile=\"$quantile\", client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "execution (q=$quantile)",
+                    "range": true,
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "chain_validation{quantile=\"$quantile\", client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "hide": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "validation (q=$quantile)",
+                    "range": true,
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "chain_write{quantile=\"$quantile\", client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "hide": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "commit (q=$quantile)",
+                    "range": true,
+                    "refId": "C"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "chain_account_reads{quantile=\"$quantile\", client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "account read (q=$quantile)",
+                    "range": true,
+                    "refId": "D"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "chain_account_updates{quantile=\"$quantile\", client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "account update (q=$quantile)",
+                    "range": true,
+                    "refId": "E"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "chain_account_hashes{quantile=\"$quantile\", client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "account hashe (q=$quantile)",
+                    "range": true,
+                    "refId": "F"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "chain_account_commits{quantile=\"$quantile\", client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "account commit (q=$quantile)",
+                    "range": true,
+                    "refId": "G"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "chain_storage_reads{quantile=\"$quantile\", client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "storage read (q=$quantile)",
+                    "range": true,
+                    "refId": "H"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "chain_storage_updates{quantile=\"$quantile\", client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "storage update (q=$quantile)",
+                    "range": true,
+                    "refId": "I"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "chain_storage_hashes{quantile=\"$quantile\", client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "storage hashe (q=$quantile)",
+                    "range": true,
+                    "refId": "J"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "chain_storage_commits{quantile=\"$quantile\", client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "storage commit (q=$quantile)",
+                    "range": true,
+                    "refId": "K"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Block processing",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ns",
+                    "logBase": 1,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 10,
+                "w": 24,
+                "x": 0,
+                "y": 53
+            },
+            "hiddenSeries": false,
+            "id": 117,
+            "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": true,
+                "min": true,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.4.7",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(txpool_valid{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "valid",
+                    "range": true,
+                    "refId": "K"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(txpool_invalid{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "invalid",
+                    "range": true,
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(txpool_underpriced{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "hide": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "underpriced",
+                    "range": true,
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(txpool_pending_discard{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "hide": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "executable discard",
+                    "range": true,
+                    "refId": "C"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(txpool_pending_replace{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "executable replace",
+                    "range": true,
+                    "refId": "D"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(txpool_pending_ratelimit{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "executable ratelimit",
+                    "range": true,
+                    "refId": "E"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(txpool_pending_nofunds{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "executable nofunds",
+                    "range": true,
+                    "refId": "F"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(txpool_queued_discard{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "hide": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "gapped discard",
+                    "range": true,
+                    "refId": "G"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(txpool_queued_replace{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "hide": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "gapped replace",
+                    "range": true,
+                    "refId": "H"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(txpool_queued_ratelimit{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "hide": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "gapped ratelimit",
+                    "range": true,
+                    "refId": "I"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(txpool_queued_nofunds{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "hide": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "gapped nofunds",
+                    "range": true,
+                    "refId": "J"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Transaction propagation",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "none",
+                    "logBase": 1,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        },
+        {
+            "collapsed": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "06O6Z894k"
+            },
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 63
+            },
+            "id": 17,
+            "panels": [],
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "06O6Z894k"
+                    },
+                    "refId": "A"
+                }
+            ],
+            "title": "Database",
+            "type": "row"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 64
+            },
+            "hiddenSeries": false,
+            "id": 35,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.4.7",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "expr": "rate(eth_db_chaindata_disk_read{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "leveldb read",
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "expr": "rate(eth_db_chaindata_disk_write{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "leveldb write",
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "expr": "rate(eth_db_chaindata_ancient_read{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "ancient read",
+                    "refId": "C"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "expr": "rate(eth_db_chaindata_ancient_write{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "ancient write",
+                    "refId": "D"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Data rate",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "Bps",
+                    "logBase": 1,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 64
+            },
+            "hiddenSeries": false,
+            "id": 118,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.4.7",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "expr": "eth_db_chaindata_disk_read{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "leveldb read",
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "expr": "eth_db_chaindata_disk_write{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "leveldb write",
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "expr": "eth_db_chaindata_ancient_read{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "ancient read",
+                    "refId": "C"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "expr": "eth_db_chaindata_ancient_write{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "ancient write",
+                    "refId": "D"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Session totals",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "decbytes",
+                    "logBase": 1,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 64
+            },
+            "hiddenSeries": false,
+            "id": 119,
+            "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.4.7",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "expr": "eth_db_chaindata_disk_size{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "leveldb",
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "expr": "eth_db_chaindata_ancient_size{client_name=~\"$client_name\", service=~\"$instance\"}",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "ancient",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Storage size",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "decbytes",
+                    "logBase": 1,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        },
+        {
+            "collapsed": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "06O6Z894k"
+            },
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 70
+            },
+            "id": 37,
+            "panels": [],
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "06O6Z894k"
+                    },
+                    "refId": "A"
+                }
+            ],
+            "title": "Trie Stats",
+            "type": "row"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 71
+            },
+            "hiddenSeries": false,
+            "id": 120,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.4.7",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "expr": "rate(trie_memcache_clean_read{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "hide": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "hit",
+                    "refId": "C"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "expr": "rate(trie_memcache_clean_write{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "hide": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "miss",
+                    "refId": "B"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Clean cache",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "Bps",
+                    "logBase": 1,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 71
+            },
+            "hiddenSeries": false,
+            "id": 56,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.4.7",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "expr": "rate(trie_memcache_gc_size{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "hide": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "gc",
+                    "refId": "C"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "expr": "rate(trie_memcache_flush_size{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "hide": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "overflow",
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "expr": "rate(trie_memcache_commit_size{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "commit",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Dirty cache",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "Bps",
+                    "logBase": 1,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        }
+    ],
+    "refresh": "10s",
+    "revision": 1,
+    "schemaVersion": 37,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                    "selected": false,
+                    "text": "Prometheus",
+                    "value": "Prometheus"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "datasource",
+                "multi": false,
+                "name": "datasource",
+                "options": [],
+                "query": "prometheus",
+                "queryValue": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "type": "datasource"
+            },
+            {
+                "current": {
+                    "selected": true,
+                    "text": "el-2-geth-lighthouse",
+                    "value": "el-2-geth-lighthouse"
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                },
+                "definition": "label_values(chain_head_block{client_name=\"$client_name\"}, service)",
+                "hide": 1,
+                "includeAll": false,
+                "label": "Instance",
+                "multi": false,
+                "name": "instance",
+                "options": [],
+                "query": {
+                    "query": "label_values(chain_head_block{client_name=\"$client_name\"}, service)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "selected": true,
+                    "text": "0.5",
+                    "value": "0.5"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "multi": false,
+                "name": "quantile",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "0.5",
+                        "value": "0.5"
+                    },
+                    {
+                        "selected": false,
+                        "text": "0.75",
+                        "value": "0.75"
+                    },
+                    {
+                        "selected": false,
+                        "text": "0.95",
+                        "value": "0.95"
+                    },
+                    {
+                        "selected": false,
+                        "text": "0.99",
+                        "value": "0.99"
+                    },
+                    {
+                        "selected": false,
+                        "text": "0.999",
+                        "value": "0.999"
+                    },
+                    {
+                        "selected": false,
+                        "text": "0.9999",
+                        "value": "0.9999"
+                    }
+                ],
+                "query": "0.5, 0.75, 0.95, 0.99, 0.999, 0.9999",
+                "queryValue": "",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "current": {
+                    "selected": true,
+                    "text": "5m",
+                    "value": "5m"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "multi": false,
+                "name": "rate",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "1m",
+                        "value": "1m"
+                    },
+                    {
+                        "selected": false,
+                        "text": "2m",
+                        "value": "2m"
+                    },
+                    {
+                        "selected": true,
+                        "text": "5m",
+                        "value": "5m"
+                    }
+                ],
+                "query": "1m, 2m, 5m",
+                "queryValue": "",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "current": {
+                    "selected": false,
+                    "text": "geth",
+                    "value": "geth"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": "Client",
+                "multi": false,
+                "name": "client_name",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "geth",
+                        "value": "geth"
+                    }
+                ],
+                "query": "geth",
+                "queryValue": "",
+                "skipUrlSync": false,
+                "type": "custom"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-24h",
+        "to": "now"
+    },
+    "timepicker": {
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "",
+    "title": "Geth Overview",
+    "uid": "FPpjH6Hik",
+    "version": 1,
+    "weekStart": ""
+}

--- a/scripts/kurtosis/data/grafana/dashboard.json
+++ b/scripts/kurtosis/data/grafana/dashboard.json
@@ -67,6 +67,7 @@
                             "tooltip": false,
                             "viz": false
                         },
+                        "insertNulls": false,
                         "lineInterpolation": "linear",
                         "lineWidth": 1,
                         "pointSize": 5,
@@ -129,7 +130,7 @@
                     "expr": "rate(miner_bundle_simulate_success_count{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
                     "format": "time_series",
                     "hide": false,
-                    "legendFormat": "success",
+                    "legendFormat": "success {{service}}",
                     "range": true,
                     "refId": "A"
                 },
@@ -141,7 +142,7 @@
                     "editorMode": "code",
                     "expr": "rate(miner_bundle_simulate_failed_count{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
                     "format": "time_series",
-                    "legendFormat": "fail",
+                    "legendFormat": "fail {{service}}",
                     "range": true,
                     "refId": "B"
                 }
@@ -173,6 +174,7 @@
                             "tooltip": false,
                             "viz": false
                         },
+                        "insertNulls": false,
                         "lineInterpolation": "linear",
                         "lineWidth": 1,
                         "pointSize": 5,
@@ -235,7 +237,7 @@
                     "expr": "rate(miner_block_build_count{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
                     "format": "time_series",
                     "hide": false,
-                    "legendFormat": "build",
+                    "legendFormat": "build {{service}}",
                     "range": true,
                     "refId": "A"
                 },
@@ -248,7 +250,7 @@
                     "expr": "rate(miner_block_merge_count{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
                     "format": "time_series",
                     "hide": false,
-                    "legendFormat": "merge",
+                    "legendFormat": "merge {{service}}",
                     "range": true,
                     "refId": "C"
                 }
@@ -280,6 +282,7 @@
                             "tooltip": false,
                             "viz": false
                         },
+                        "insertNulls": false,
                         "lineInterpolation": "linear",
                         "lineWidth": 1,
                         "pointSize": 5,
@@ -343,7 +346,7 @@
                     "exemplar": false,
                     "expr": "rate(miner_block_profit_gauge{client_name=~\"$client_name\", service=~\"$instance\"}[$rate]) / 1000000000",
                     "hide": false,
-                    "legendFormat": "build",
+                    "legendFormat": "build {{service}}",
                     "range": true,
                     "refId": "A"
                 }
@@ -388,6 +391,7 @@
                             "tooltip": false,
                             "viz": false
                         },
+                        "insertNulls": false,
                         "lineInterpolation": "linear",
                         "lineWidth": 1,
                         "pointSize": 5,
@@ -448,7 +452,7 @@
                     },
                     "editorMode": "code",
                     "expr": "rate(rpc_duration_eth_callBundle_success_count{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
-                    "legendFormat": "success",
+                    "legendFormat": "success {{service}}",
                     "range": true,
                     "refId": "A"
                 },
@@ -460,7 +464,7 @@
                     "editorMode": "code",
                     "expr": "rate(rpc_duration_eth_callBundle_failure_count{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
                     "hide": false,
-                    "legendFormat": "failure",
+                    "legendFormat": "failure {{service}}",
                     "range": true,
                     "refId": "B"
                 }
@@ -492,6 +496,7 @@
                             "tooltip": false,
                             "viz": false
                         },
+                        "insertNulls": false,
                         "lineInterpolation": "linear",
                         "lineWidth": 1,
                         "pointSize": 5,
@@ -584,6 +589,7 @@
                             "tooltip": false,
                             "viz": false
                         },
+                        "insertNulls": false,
                         "lineInterpolation": "linear",
                         "lineWidth": 1,
                         "pointSize": 5,
@@ -689,6 +695,7 @@
                             "tooltip": false,
                             "viz": false
                         },
+                        "insertNulls": false,
                         "lineInterpolation": "linear",
                         "lineWidth": 1,
                         "pointSize": 5,
@@ -749,7 +756,7 @@
                     },
                     "editorMode": "code",
                     "expr": "rate(rpc_duration_flashbots_validateBuilderSubmissionV2_success_count{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
-                    "legendFormat": "success",
+                    "legendFormat": "success {{service}}",
                     "range": true,
                     "refId": "A"
                 },
@@ -761,7 +768,7 @@
                     "editorMode": "code",
                     "expr": "rate(rpc_duration_flashbots_validateBuilderSubmissionV2_failure_count{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
                     "hide": false,
-                    "legendFormat": "failure",
+                    "legendFormat": "failure {{service}}",
                     "range": true,
                     "refId": "B"
                 }
@@ -793,6 +800,7 @@
                             "tooltip": false,
                             "viz": false
                         },
+                        "insertNulls": false,
                         "lineInterpolation": "linear",
                         "lineWidth": 1,
                         "pointSize": 5,
@@ -858,7 +866,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Durations of successful eth_callBundle calls",
+            "title": "Durations of successful flashbots_validateBuilderSubmissionV2 calls",
             "type": "timeseries"
         },
         {
@@ -885,6 +893,7 @@
                             "tooltip": false,
                             "viz": false
                         },
+                        "insertNulls": false,
                         "lineInterpolation": "linear",
                         "lineWidth": 1,
                         "pointSize": 5,
@@ -944,7 +953,7 @@
                         "uid": "${datasource}"
                     },
                     "editorMode": "code",
-                    "expr": "rpc_duration_flashbots_validateBuilderSubmissionV2_success{quantile=\"$quantile\", client_name=~\"$client_name\", service=~\"$instance\"} / 1000",
+                    "expr": "rpc_duration_flashbots_validateBuilderSubmissionV2_failure{quantile=\"$quantile\", client_name=~\"$client_name\", service=~\"$instance\"} / 1000",
                     "legendFormat": "{{service}}",
                     "range": true,
                     "refId": "A"
@@ -1017,7 +1026,7 @@
                 "alertThreshold": true
             },
             "percentage": false,
-            "pluginVersion": "9.4.7",
+            "pluginVersion": "10.1.2",
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
@@ -1036,7 +1045,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "system",
+                    "legendFormat": "system {{service}}",
                     "range": true,
                     "refId": "A"
                 },
@@ -1050,7 +1059,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "iowait",
+                    "legendFormat": "iowait {{service}}",
                     "range": true,
                     "refId": "B"
                 },
@@ -1064,7 +1073,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "geth",
+                    "legendFormat": "geth {{service}}",
                     "range": true,
                     "refId": "C"
                 }
@@ -1137,7 +1146,7 @@
                 "alertThreshold": true
             },
             "percentage": false,
-            "pluginVersion": "9.4.7",
+            "pluginVersion": "10.1.2",
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
@@ -1156,7 +1165,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "alloc",
+                    "legendFormat": "alloc {{service}}",
                     "range": true,
                     "refId": "A"
                 },
@@ -1170,7 +1179,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "used",
+                    "legendFormat": "used {{service}}",
                     "range": true,
                     "refId": "B"
                 },
@@ -1184,7 +1193,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "held",
+                    "legendFormat": "held {{service}}",
                     "range": true,
                     "refId": "C"
                 }
@@ -1257,7 +1266,7 @@
                 "alertThreshold": true
             },
             "percentage": false,
-            "pluginVersion": "9.4.7",
+            "pluginVersion": "10.1.2",
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
@@ -1276,7 +1285,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "read",
+                    "legendFormat": "read {{service}}",
                     "range": true,
                     "refId": "A"
                 },
@@ -1290,7 +1299,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "write",
+                    "legendFormat": "write {{service}}",
                     "range": true,
                     "refId": "B"
                 }
@@ -1389,7 +1398,7 @@
                 "alertThreshold": true
             },
             "percentage": false,
-            "pluginVersion": "9.4.7",
+            "pluginVersion": "10.1.2",
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
@@ -1408,7 +1417,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "ingress",
+                    "legendFormat": "ingress {{service}}",
                     "range": true,
                     "refId": "B"
                 },
@@ -1422,7 +1431,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "egress",
+                    "legendFormat": "egress {{service}}",
                     "range": true,
                     "refId": "C"
                 }
@@ -1495,7 +1504,7 @@
                 "alertThreshold": true
             },
             "percentage": false,
-            "pluginVersion": "9.4.7",
+            "pluginVersion": "10.1.2",
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
@@ -1514,7 +1523,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "peers",
+                    "legendFormat": "peers {{service}}",
                     "range": true,
                     "refId": "A"
                 },
@@ -1528,7 +1537,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "dials",
+                    "legendFormat": "dials {{service}}",
                     "range": true,
                     "refId": "B"
                 },
@@ -1542,7 +1551,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "serves",
+                    "legendFormat": "serves {{service}}",
                     "range": true,
                     "refId": "C"
                 }
@@ -1630,7 +1639,8 @@
                         "mode": "absolute",
                         "steps": [
                             {
-                                "color": "rgb(252, 252, 252)"
+                                "color": "rgb(252, 252, 252)",
+                                "value": null
                             }
                         ]
                     },
@@ -1639,8 +1649,8 @@
                 "overrides": []
             },
             "gridPos": {
-                "h": 2,
-                "w": 3,
+                "h": 3,
+                "w": 6,
                 "x": 0,
                 "y": 36
             },
@@ -1660,9 +1670,9 @@
                     "values": false
                 },
                 "text": {},
-                "textMode": "auto"
+                "textMode": "value"
             },
-            "pluginVersion": "9.4.7",
+            "pluginVersion": "10.1.2",
             "targets": [
                 {
                     "datasource": {
@@ -1707,6 +1717,7 @@
                             "tooltip": false,
                             "viz": false
                         },
+                        "insertNulls": false,
                         "lineInterpolation": "stepAfter",
                         "lineWidth": 1,
                         "pointSize": 5,
@@ -1728,7 +1739,8 @@
                         "mode": "absolute",
                         "steps": [
                             {
-                                "color": "green"
+                                "color": "green",
+                                "value": null
                             }
                         ]
                     },
@@ -1737,9 +1749,9 @@
                 "overrides": []
             },
             "gridPos": {
-                "h": 6,
-                "w": 9,
-                "x": 3,
+                "h": 9,
+                "w": 18,
+                "x": 6,
                 "y": 36
             },
             "id": 110,
@@ -1768,7 +1780,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "header",
+                    "legendFormat": "header {{service}}",
                     "range": true,
                     "refId": "A"
                 },
@@ -1782,7 +1794,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "receipt",
+                    "legendFormat": "receipt {{service}}",
                     "range": true,
                     "refId": "B"
                 },
@@ -1796,7 +1808,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "block",
+                    "legendFormat": "block {{service}}",
                     "range": true,
                     "refId": "C"
                 }
@@ -1829,7 +1841,164 @@
                         "mode": "absolute",
                         "steps": [
                             {
-                                "color": "rgb(255, 255, 255)"
+                                "color": "rgb(255, 255, 255)",
+                                "value": null
+                            }
+                        ]
+                    },
+                    "unit": "locale"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 3,
+                "w": 6,
+                "x": 0,
+                "y": 39
+            },
+            "id": 111,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "10.1.2",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "max(chain_head_receipt{client_name=~\"$client_name\", service=~\"$instance\"})",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{service}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Latest receipt",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "rgb(255, 255, 255)",
+                                "value": null
+                            }
+                        ]
+                    },
+                    "unit": "locale"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 3,
+                "w": 6,
+                "x": 0,
+                "y": 42
+            },
+            "id": 109,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "10.1.2",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "max(chain_head_block{client_name=~\"$client_name\", service=~\"$instance\"})",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{service}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Latest block",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "rgb(255, 255, 255)",
+                                "value": null
                             }
                         ]
                     },
@@ -1838,10 +2007,10 @@
                 "overrides": []
             },
             "gridPos": {
-                "h": 2,
-                "w": 3,
-                "x": 12,
-                "y": 36
+                "h": 3,
+                "w": 6,
+                "x": 0,
+                "y": 45
             },
             "id": 113,
             "links": [],
@@ -1861,7 +2030,7 @@
                 "text": {},
                 "textMode": "auto"
             },
-            "pluginVersion": "9.4.7",
+            "pluginVersion": "10.1.2",
             "targets": [
                 {
                     "datasource": {
@@ -1893,10 +2062,10 @@
             "fill": 1,
             "fillGradient": 0,
             "gridPos": {
-                "h": 6,
-                "w": 9,
-                "x": 15,
-                "y": 36
+                "h": 9,
+                "w": 18,
+                "x": 6,
+                "y": 45
             },
             "hiddenSeries": false,
             "id": 116,
@@ -1917,7 +2086,7 @@
                 "alertThreshold": true
             },
             "percentage": false,
-            "pluginVersion": "9.4.7",
+            "pluginVersion": "10.1.2",
             "pointradius": 2,
             "points": false,
             "renderer": "flot",
@@ -1936,7 +2105,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "executable",
+                    "legendFormat": "executable {{service}}",
                     "range": true,
                     "refId": "A"
                 },
@@ -1950,7 +2119,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "gapped",
+                    "legendFormat": "gapped {{service}}",
                     "range": true,
                     "refId": "B"
                 },
@@ -1964,7 +2133,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "local",
+                    "legendFormat": "local {{service}}",
                     "range": true,
                     "refId": "C"
                 }
@@ -2024,84 +2193,8 @@
                         "mode": "absolute",
                         "steps": [
                             {
-                                "color": "rgb(255, 255, 255)"
-                            }
-                        ]
-                    },
-                    "unit": "locale"
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 2,
-                "w": 3,
-                "x": 0,
-                "y": 38
-            },
-            "id": 111,
-            "links": [],
-            "maxDataPoints": 100,
-            "options": {
-                "colorMode": "value",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "horizontal",
-                "reduceOptions": {
-                    "calcs": [
-                        "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                },
-                "text": {},
-                "textMode": "auto"
-            },
-            "pluginVersion": "9.4.7",
-            "targets": [
-                {
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                    },
-                    "editorMode": "code",
-                    "expr": "max(chain_head_receipt{client_name=~\"$client_name\", service=~\"$instance\"})",
-                    "format": "time_series",
-                    "interval": "",
-                    "intervalFactor": 1,
-                    "legendFormat": "{{service}}",
-                    "range": true,
-                    "refId": "A"
-                }
-            ],
-            "title": "Latest receipt",
-            "type": "stat"
-        },
-        {
-            "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-            },
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "thresholds"
-                    },
-                    "mappings": [
-                        {
-                            "options": {
-                                "match": "null",
-                                "result": {
-                                    "text": "N/A"
-                                }
-                            },
-                            "type": "special"
-                        }
-                    ],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "rgb(255, 255, 255)"
+                                "color": "rgb(255, 255, 255)",
+                                "value": null
                             }
                         ]
                     },
@@ -2110,10 +2203,10 @@
                 "overrides": []
             },
             "gridPos": {
-                "h": 2,
-                "w": 3,
-                "x": 12,
-                "y": 38
+                "h": 3,
+                "w": 6,
+                "x": 0,
+                "y": 48
             },
             "id": 114,
             "links": [],
@@ -2133,7 +2226,7 @@
                 "text": {},
                 "textMode": "auto"
             },
-            "pluginVersion": "9.4.7",
+            "pluginVersion": "10.1.2",
             "targets": [
                 {
                     "datasource": {
@@ -2178,84 +2271,8 @@
                         "mode": "absolute",
                         "steps": [
                             {
-                                "color": "rgb(255, 255, 255)"
-                            }
-                        ]
-                    },
-                    "unit": "locale"
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 2,
-                "w": 3,
-                "x": 0,
-                "y": 40
-            },
-            "id": 109,
-            "links": [],
-            "maxDataPoints": 100,
-            "options": {
-                "colorMode": "value",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "horizontal",
-                "reduceOptions": {
-                    "calcs": [
-                        "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                },
-                "text": {},
-                "textMode": "auto"
-            },
-            "pluginVersion": "9.4.7",
-            "targets": [
-                {
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                    },
-                    "editorMode": "code",
-                    "expr": "max(chain_head_block{client_name=~\"$client_name\", service=~\"$instance\"})",
-                    "format": "time_series",
-                    "interval": "",
-                    "intervalFactor": 1,
-                    "legendFormat": "{{service}}",
-                    "range": true,
-                    "refId": "A"
-                }
-            ],
-            "title": "Latest block",
-            "type": "stat"
-        },
-        {
-            "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-            },
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "thresholds"
-                    },
-                    "mappings": [
-                        {
-                            "options": {
-                                "match": "null",
-                                "result": {
-                                    "text": "N/A"
-                                }
-                            },
-                            "type": "special"
-                        }
-                    ],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "rgb(255, 255, 255)"
+                                "color": "rgb(255, 255, 255)",
+                                "value": null
                             }
                         ]
                     },
@@ -2264,10 +2281,10 @@
                 "overrides": []
             },
             "gridPos": {
-                "h": 2,
-                "w": 3,
-                "x": 12,
-                "y": 40
+                "h": 3,
+                "w": 6,
+                "x": 0,
+                "y": 51
             },
             "id": 115,
             "links": [],
@@ -2287,7 +2304,7 @@
                 "text": {},
                 "textMode": "auto"
             },
-            "pluginVersion": "9.4.7",
+            "pluginVersion": "10.1.2",
             "targets": [
                 {
                     "datasource": {
@@ -2322,7 +2339,7 @@
                 "h": 11,
                 "w": 24,
                 "x": 0,
-                "y": 42
+                "y": 54
             },
             "hiddenSeries": false,
             "id": 112,
@@ -2345,7 +2362,7 @@
                 "alertThreshold": true
             },
             "percentage": false,
-            "pluginVersion": "9.4.7",
+            "pluginVersion": "10.1.2",
             "pointradius": 2,
             "points": false,
             "renderer": "flot",
@@ -2364,7 +2381,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "execution (q=$quantile)",
+                    "legendFormat": "execution (q=$quantile) {{service}}",
                     "range": true,
                     "refId": "A"
                 },
@@ -2379,7 +2396,7 @@
                     "hide": false,
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "validation (q=$quantile)",
+                    "legendFormat": "validation (q=$quantile) {{service}}",
                     "range": true,
                     "refId": "B"
                 },
@@ -2394,7 +2411,7 @@
                     "hide": false,
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "commit (q=$quantile)",
+                    "legendFormat": "commit (q=$quantile) {{service}}",
                     "range": true,
                     "refId": "C"
                 },
@@ -2408,7 +2425,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "account read (q=$quantile)",
+                    "legendFormat": "account read (q=$quantile) {{service}}",
                     "range": true,
                     "refId": "D"
                 },
@@ -2422,7 +2439,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "account update (q=$quantile)",
+                    "legendFormat": "account update (q=$quantile) {{service}}",
                     "range": true,
                     "refId": "E"
                 },
@@ -2436,7 +2453,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "account hashe (q=$quantile)",
+                    "legendFormat": "account hashe (q=$quantile) {{service}}",
                     "range": true,
                     "refId": "F"
                 },
@@ -2450,7 +2467,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "account commit (q=$quantile)",
+                    "legendFormat": "account commit (q=$quantile) {{service}}",
                     "range": true,
                     "refId": "G"
                 },
@@ -2464,7 +2481,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "storage read (q=$quantile)",
+                    "legendFormat": "storage read (q=$quantile) {{service}}",
                     "range": true,
                     "refId": "H"
                 },
@@ -2478,7 +2495,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "storage update (q=$quantile)",
+                    "legendFormat": "storage update (q=$quantile) {{service}}",
                     "range": true,
                     "refId": "I"
                 },
@@ -2492,7 +2509,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "storage hashe (q=$quantile)",
+                    "legendFormat": "storage hashe (q=$quantile) {{service}}",
                     "range": true,
                     "refId": "J"
                 },
@@ -2506,7 +2523,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "storage commit (q=$quantile)",
+                    "legendFormat": "storage commit (q=$quantile) {{service}}",
                     "range": true,
                     "refId": "K"
                 }
@@ -2556,7 +2573,7 @@
                 "h": 10,
                 "w": 24,
                 "x": 0,
-                "y": 53
+                "y": 65
             },
             "hiddenSeries": false,
             "id": 117,
@@ -2579,7 +2596,7 @@
                 "alertThreshold": true
             },
             "percentage": false,
-            "pluginVersion": "9.4.7",
+            "pluginVersion": "10.1.2",
             "pointradius": 2,
             "points": false,
             "renderer": "flot",
@@ -2598,7 +2615,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "valid",
+                    "legendFormat": "valid {{service}}",
                     "range": true,
                     "refId": "K"
                 },
@@ -2612,7 +2629,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "invalid",
+                    "legendFormat": "invalid {{service}}",
                     "range": true,
                     "refId": "A"
                 },
@@ -2627,7 +2644,7 @@
                     "hide": false,
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "underpriced",
+                    "legendFormat": "underpriced {{service}}",
                     "range": true,
                     "refId": "B"
                 },
@@ -2642,7 +2659,7 @@
                     "hide": false,
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "executable discard",
+                    "legendFormat": "executable discard {{service}}",
                     "range": true,
                     "refId": "C"
                 },
@@ -2656,7 +2673,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "executable replace",
+                    "legendFormat": "executable replace {{service}}",
                     "range": true,
                     "refId": "D"
                 },
@@ -2670,7 +2687,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "executable ratelimit",
+                    "legendFormat": "executable ratelimit {{service}}",
                     "range": true,
                     "refId": "E"
                 },
@@ -2684,7 +2701,7 @@
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "executable nofunds",
+                    "legendFormat": "executable nofunds {{service}}",
                     "range": true,
                     "refId": "F"
                 },
@@ -2699,7 +2716,7 @@
                     "hide": false,
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "gapped discard",
+                    "legendFormat": "gapped discard {{service}}",
                     "range": true,
                     "refId": "G"
                 },
@@ -2714,7 +2731,7 @@
                     "hide": false,
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "gapped replace",
+                    "legendFormat": "gapped replace {{service}}",
                     "range": true,
                     "refId": "H"
                 },
@@ -2729,7 +2746,7 @@
                     "hide": false,
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "gapped ratelimit",
+                    "legendFormat": "gapped ratelimit {{service}}",
                     "range": true,
                     "refId": "I"
                 },
@@ -2744,7 +2761,7 @@
                     "hide": false,
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "gapped nofunds",
+                    "legendFormat": "gapped nofunds {{service}}",
                     "range": true,
                     "refId": "J"
                 }
@@ -2789,7 +2806,7 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 63
+                "y": 75
             },
             "id": 17,
             "panels": [],
@@ -2817,10 +2834,10 @@
             "fill": 1,
             "fillGradient": 0,
             "gridPos": {
-                "h": 6,
+                "h": 8,
                 "w": 8,
                 "x": 0,
-                "y": 64
+                "y": 76
             },
             "hiddenSeries": false,
             "id": 35,
@@ -2841,7 +2858,7 @@
                 "alertThreshold": true
             },
             "percentage": false,
-            "pluginVersion": "9.4.7",
+            "pluginVersion": "10.1.2",
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
@@ -2855,11 +2872,13 @@
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
+                    "editorMode": "code",
                     "expr": "rate(eth_db_chaindata_disk_read{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "leveldb read",
+                    "legendFormat": "leveldb read {{service}}",
+                    "range": true,
                     "refId": "B"
                 },
                 {
@@ -2867,11 +2886,13 @@
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
+                    "editorMode": "code",
                     "expr": "rate(eth_db_chaindata_disk_write{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "leveldb write",
+                    "legendFormat": "leveldb write {{service}}",
+                    "range": true,
                     "refId": "A"
                 },
                 {
@@ -2879,11 +2900,13 @@
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
+                    "editorMode": "code",
                     "expr": "rate(eth_db_chaindata_ancient_read{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "ancient read",
+                    "legendFormat": "ancient read {{service}}",
+                    "range": true,
                     "refId": "C"
                 },
                 {
@@ -2891,11 +2914,13 @@
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
+                    "editorMode": "code",
                     "expr": "rate(eth_db_chaindata_ancient_write{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "ancient write",
+                    "legendFormat": "ancient write {{service}}",
+                    "range": true,
                     "refId": "D"
                 }
             ],
@@ -2941,10 +2966,10 @@
             "fill": 1,
             "fillGradient": 0,
             "gridPos": {
-                "h": 6,
+                "h": 8,
                 "w": 8,
                 "x": 8,
-                "y": 64
+                "y": 76
             },
             "hiddenSeries": false,
             "id": 118,
@@ -2965,7 +2990,7 @@
                 "alertThreshold": true
             },
             "percentage": false,
-            "pluginVersion": "9.4.7",
+            "pluginVersion": "10.1.2",
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
@@ -2979,11 +3004,13 @@
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
+                    "editorMode": "code",
                     "expr": "eth_db_chaindata_disk_read{client_name=~\"$client_name\", service=~\"$instance\"}",
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "leveldb read",
+                    "legendFormat": "leveldb read {{service}}",
+                    "range": true,
                     "refId": "B"
                 },
                 {
@@ -2991,11 +3018,13 @@
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
+                    "editorMode": "code",
                     "expr": "eth_db_chaindata_disk_write{client_name=~\"$client_name\", service=~\"$instance\"}",
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "leveldb write",
+                    "legendFormat": "leveldb write {{service}}",
+                    "range": true,
                     "refId": "A"
                 },
                 {
@@ -3003,11 +3032,13 @@
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
+                    "editorMode": "code",
                     "expr": "eth_db_chaindata_ancient_read{client_name=~\"$client_name\", service=~\"$instance\"}",
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "ancient read",
+                    "legendFormat": "ancient read {{service}}",
+                    "range": true,
                     "refId": "C"
                 },
                 {
@@ -3015,11 +3046,13 @@
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
+                    "editorMode": "code",
                     "expr": "eth_db_chaindata_ancient_write{client_name=~\"$client_name\", service=~\"$instance\"}",
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "ancient write",
+                    "legendFormat": "ancient write {{service}}",
+                    "range": true,
                     "refId": "D"
                 }
             ],
@@ -3065,10 +3098,10 @@
             "fill": 1,
             "fillGradient": 0,
             "gridPos": {
-                "h": 6,
+                "h": 8,
                 "w": 8,
                 "x": 16,
-                "y": 64
+                "y": 76
             },
             "hiddenSeries": false,
             "id": 119,
@@ -3091,7 +3124,7 @@
                 "alertThreshold": true
             },
             "percentage": false,
-            "pluginVersion": "9.4.7",
+            "pluginVersion": "10.1.2",
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
@@ -3105,11 +3138,13 @@
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
+                    "editorMode": "code",
                     "expr": "eth_db_chaindata_disk_size{client_name=~\"$client_name\", service=~\"$instance\"}",
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "leveldb",
+                    "legendFormat": "leveldb {{service}}",
+                    "range": true,
                     "refId": "B"
                 },
                 {
@@ -3117,11 +3152,13 @@
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
+                    "editorMode": "code",
                     "expr": "eth_db_chaindata_ancient_size{client_name=~\"$client_name\", service=~\"$instance\"}",
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "ancient",
+                    "legendFormat": "ancient {{service}}",
+                    "range": true,
                     "refId": "A"
                 }
             ],
@@ -3165,7 +3202,7 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 70
+                "y": 84
             },
             "id": 37,
             "panels": [],
@@ -3196,7 +3233,7 @@
                 "h": 6,
                 "w": 12,
                 "x": 0,
-                "y": 71
+                "y": 85
             },
             "hiddenSeries": false,
             "id": 120,
@@ -3217,7 +3254,7 @@
                 "alertThreshold": true
             },
             "percentage": false,
-            "pluginVersion": "9.4.7",
+            "pluginVersion": "10.1.2",
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
@@ -3231,12 +3268,14 @@
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
+                    "editorMode": "code",
                     "expr": "rate(trie_memcache_clean_read{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
                     "format": "time_series",
                     "hide": false,
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "hit",
+                    "legendFormat": "hit {{service}}",
+                    "range": true,
                     "refId": "C"
                 },
                 {
@@ -3244,12 +3283,14 @@
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
+                    "editorMode": "code",
                     "expr": "rate(trie_memcache_clean_write{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
                     "format": "time_series",
                     "hide": false,
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "miss",
+                    "legendFormat": "miss {{service}}",
+                    "range": true,
                     "refId": "B"
                 }
             ],
@@ -3298,7 +3339,7 @@
                 "h": 6,
                 "w": 12,
                 "x": 12,
-                "y": 71
+                "y": 85
             },
             "hiddenSeries": false,
             "id": 56,
@@ -3319,7 +3360,7 @@
                 "alertThreshold": true
             },
             "percentage": false,
-            "pluginVersion": "9.4.7",
+            "pluginVersion": "10.1.2",
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
@@ -3333,12 +3374,14 @@
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
+                    "editorMode": "code",
                     "expr": "rate(trie_memcache_gc_size{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
                     "format": "time_series",
                     "hide": false,
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "gc",
+                    "legendFormat": "gc {{service}}",
+                    "range": true,
                     "refId": "C"
                 },
                 {
@@ -3346,12 +3389,14 @@
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
+                    "editorMode": "code",
                     "expr": "rate(trie_memcache_flush_size{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
                     "format": "time_series",
                     "hide": false,
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "overflow",
+                    "legendFormat": "overflow {{service}}",
+                    "range": true,
                     "refId": "B"
                 },
                 {
@@ -3359,11 +3404,13 @@
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
+                    "editorMode": "code",
                     "expr": "rate(trie_memcache_commit_size{client_name=~\"$client_name\", service=~\"$instance\"}[$rate])",
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "commit",
+                    "legendFormat": "commit {{service}}",
+                    "range": true,
                     "refId": "A"
                 }
             ],
@@ -3400,7 +3447,7 @@
     ],
     "refresh": "10s",
     "revision": 1,
-    "schemaVersion": 37,
+    "schemaVersion": 38,
     "style": "dark",
     "tags": [],
     "templating": {
@@ -3409,7 +3456,7 @@
                 "current": {
                     "selected": false,
                     "text": "Prometheus",
-                    "value": "Prometheus"
+                    "value": "PBFA97CFB590B2093"
                 },
                 "hide": 0,
                 "includeAll": false,
@@ -3427,8 +3474,12 @@
             {
                 "current": {
                     "selected": true,
-                    "text": "el-2-geth-lighthouse",
-                    "value": "el-2-geth-lighthouse"
+                    "text": [
+                        "All"
+                    ],
+                    "value": [
+                        "$__all"
+                    ]
                 },
                 "datasource": {
                     "type": "prometheus",
@@ -3436,9 +3487,9 @@
                 },
                 "definition": "label_values(chain_head_block{client_name=\"$client_name\"}, service)",
                 "hide": 1,
-                "includeAll": false,
+                "includeAll": true,
                 "label": "Instance",
-                "multi": false,
+                "multi": true,
                 "name": "instance",
                 "options": [],
                 "query": {
@@ -3556,7 +3607,7 @@
         ]
     },
     "time": {
-        "from": "now-24h",
+        "from": "now-5m",
         "to": "now"
     },
     "timepicker": {
@@ -3585,7 +3636,7 @@
         ]
     },
     "timezone": "",
-    "title": "Geth Overview",
+    "title": "Geth Builder Overview",
     "uid": "FPpjH6Hik",
     "version": 1,
     "weekStart": ""

--- a/scripts/kurtosis/kurtosis.yml
+++ b/scripts/kurtosis/kurtosis.yml
@@ -1,0 +1,1 @@
+﻿name: "github.com/flashbots/builder-startup-script"

--- a/scripts/kurtosis/main.star
+++ b/scripts/kurtosis/main.star
@@ -1,0 +1,10 @@
+#Use: kurtosis.exe run  --enclave explorer ./kurtosis/ '{file_to_read=C:\work\builder\builder\scripts\kurtosis\network_params.json}'
+eth_pkg = import_module(
+    "github.com/kurtosis-tech/ethereum-package/main.star"
+)
+
+def run(plan, file_to_read = "network_params.json"):
+    inputs = json.decode(read_file(src=file_to_read))
+    plan.print(inputs)
+    eth_pkg.run(plan, inputs)
+

--- a/scripts/kurtosis/main.star
+++ b/scripts/kurtosis/main.star
@@ -1,10 +1,11 @@
-#Use: kurtosis.exe run  --enclave explorer ./kurtosis/ '{file_to_read=C:\work\builder\builder\scripts\kurtosis\network_params.json}'
+#Use: kurtosis.exe run  --enclave explorer ./kurtosis/ '{"file_to_read": "./network_params.json"}'
+#Node: works only with config files local to ./kurtosis/ folder where kurtosis.yml is defined
+
 eth_pkg = import_module(
-    "github.com/kurtosis-tech/ethereum-package/main.star"
+    "github.com/kurtosis-tech/ethereum-package/main.star@0.6.1"
 )
 
-def run(plan, file_to_read = "network_params.json"):
+def run(plan, file_to_read = "network_params_tmp.json"):
     inputs = json.decode(read_file(src=file_to_read))
     plan.print(inputs)
     eth_pkg.run(plan, inputs)
-

--- a/scripts/kurtosis/network_params.json
+++ b/scripts/kurtosis/network_params.json
@@ -1,0 +1,69 @@
+{
+    "mev_type": "full",
+    "participants": [
+        {
+            "el_client_type": "nethermind",
+            "el_client_image": "nethermind/nethermind:1.21.0",
+            "el_client_log_level": "",
+            "cl_client_type": "lighthouse",
+            "cl_client_log_level": "",
+            "cl_client_image": "sigp/lighthouse:v4.5.0",
+            "el_extra_params": [],
+            "beacon_extra_params": [
+                "--always-prefer-builder-payload",
+                "--disable-peer-scoring"
+            ]
+        },
+        {
+            "el_client_type": "geth",
+            "el_client_image": "ethpandaops/flashbots-builder:main-45e865e",
+            "el_client_log_level": "",
+            "cl_client_type": "lighthouse",
+            "cl_client_image": "sigp/lighthouse:v4.5.0",
+            "cl_client_log_level": "",
+            "beacon_extra_params": [
+                "--always-prepare-payload",
+                "--prepare-payload-lookahead",
+                "12000",
+                "--disable-peer-scoring"
+            ],
+            "el_extra_params": [
+                "--builder",
+                "--builder.remote_relay_endpoint=http://mev-relay-api:9062",
+                "--builder.beacon_endpoints=http://cl-2-lighthouse-geth:4000",
+                "--builder.bellatrix_fork_version=0x30000038",
+                "--builder.genesis_fork_version=0x10000038",
+                "--builder.genesis_validators_root=GENESIS_VALIDATORS_ROOT_PLACEHOLDER",
+                "--miner.extradata=The_Dev_version_of_builder",
+                "--builder.algotype=greedy",
+				"--metrics.builder=true"
+            ],
+            "validator_count": 0,
+            "el_extra_env_vars": {
+                "BUILDER_TX_SIGNING_KEY": "0xef5177cd0b6b21c87db5a0bf35d4084a8a57a9d6a064f86d51ac85f2b873a4e2"
+            }
+        }
+    ],
+    "network_params": {"capella_fork_epoch": 1, "seconds_per_slot": 12},
+    "mev_params": {
+        "mev_flood_seconds_per_bundle": 13,
+        "launch_custom_flood": true,
+        "mev_flood_extra_args": ["--txsPerBundle=250"],
+        "mev_flood_image": "flashbots/mev-flood:0.0.9",
+        "mev_relay_image": "flashbots/mev-boost-relay:0.26",
+        "mev_boost_image": "flashbots/mev-boost:1.6",
+        "mev_builder_image": "ethpandaops/flashbots-builder:main-45e865e"
+    },
+    "additional_services": [
+        "tx_spammer",
+        "blob_spammer",
+        "beacon_metrics_gazer",
+        "dora",
+        "prometheus_grafana"
+    ],
+    "tx_spammer_params": {"tx_spammer_extra_args": ["--txcount=250"]},
+    "grafana_additional_dashboards": [
+        "github.com/flashbots/builder-startup-script/data/grafana/dashboard.json",
+    	"github.com/flashbots/builder-startup-script/data/grafana"
+    ]
+}

--- a/scripts/kurtosis/network_params.json
+++ b/scripts/kurtosis/network_params.json
@@ -15,7 +15,7 @@
             ]
         },
         {
-            "el_client_type": "geth",
+            "el_client_type": "REPLACE_WITH_BUILDER",
             "el_client_image": "ethpandaops/flashbots-builder:main-45e865e",
             "el_client_log_level": "",
             "cl_client_type": "lighthouse",

--- a/scripts/kurtosis/network_params.json
+++ b/scripts/kurtosis/network_params.json
@@ -48,11 +48,11 @@
     "mev_params": {
         "mev_flood_seconds_per_bundle": 13,
         "launch_custom_flood": true,
-        "mev_flood_extra_args": ["--txsPerBundle=250"],
+        "mev_flood_extra_args": ["--txsPerBundle=100"],
         "mev_flood_image": "flashbots/mev-flood:0.0.9",
-        "mev_relay_image": "flashbots/mev-boost-relay:0.26",
+        "mev_relay_image": "flashbots/mev-boost-relay:0.27",
         "mev_boost_image": "flashbots/mev-boost:1.6",
-        "mev_builder_image": "ethpandaops/flashbots-builder:main-45e865e"
+        "mev_builder_image": "flashbots/builder:latest"
     },
     "additional_services": [
         "tx_spammer",
@@ -61,7 +61,7 @@
         "dora",
         "prometheus_grafana"
     ],
-    "tx_spammer_params": {"tx_spammer_extra_args": ["--txcount=250"]},
+    "tx_spammer_params": {"tx_spammer_extra_args": ["--txcount=100"]},
     "grafana_additional_dashboards": [
         "github.com/flashbots/builder-startup-script/data/grafana/dashboard.json",
     	"github.com/flashbots/builder-startup-script/data/grafana"

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -1,0 +1,86 @@
+# Emulate Network script
+
+This README accompanies the `emulate_network.go` Go script, which uses Docker, Kurtosis, and the Kurtosis Ethereum-Package enclave to test builder performance.
+
+## Introduction
+
+This script streamlines and automates the process of (re-)building the current builder Docker image and interfacing with the Kurtosis platform. It offers a set of commands to assist developers in routine tasks, such as (re-)building Docker images and managing Kurtosis enclaves.
+
+
+## Running in dev environment
+
+### Prerequisites
+
+Before using the script, ensure you have the following installed:
+
+1. **Go**: Ensure you have Go installed. Download and install it from [here](https://golang.org/dl/).
+
+2. **Docker**: The build process needs Docker. Make sure Docker is installed and running. Check out the [Docker website](https://www.docker.com/get-started) for installation instructions.
+
+3. **Kurtosis**: The script interfaces with the Kurtosis platform. Ensure `kurtosis` is installed and available in your PATH. Refer to [Kurtosis's official documentation](https://docs.kurtosistech.com/installation.html) for installation details.
+
+4. **ethereum-package**: This script utilizes a modified ethereum-package network configuration, which will be downloaded from [repo](github.com/kurtosis-tech/ethereum-package/) main brunch automatically.
+
+### How to Run
+
+To execute the script with Go, navigate to the directory containing the script and run:
+
+```
+go run emulate_network.go <COMMAND_NAME> [OPTIONS]
+```
+
+Replace `<COMMAND_NAME>` with one of the available commands and provide the necessary options.
+
+### Commands and Options
+To run script `cd` into this (`./scripts`) folder.
+
+1. **build**:
+   - Purpose: Builds a Docker image of the builder.
+   - Options:
+      - `-t`: (Optional) Image tag for the Docker build. Defaults to `flashbots/builder:dev`.
+   - Example:
+     ```
+     go run emulate_network.go build -t=test-builder
+     ```
+
+2. **run**:
+   - Purpose: Prepares configurations and starts a Kurtosis enclave.
+   - Options:
+      - `-t`: (Optional) Image tag. Defaults to `flashbots/builder:dev`.
+      - `-n`: (Optional) Enclave name. Defaults to `explorer`.
+      - `-a`: (Optional) Additional builder arguments.
+      - `-s`: (Optional) Max steps (integer). Default `-1` for "unlimited".
+      - `-k`: (Optional) Path to `kurtosis` executable. Defaults to `kurtosis`.
+      - `-c`: (Required) Kurtosis network config path to *ethereum-package* repo.
+   - Example:
+     ```
+     go run emulate_network.go run -t=imageTag -a=imageArgs -n=enclaveName -k=/path/to/kurtosis
+     ```
+
+3. **stop**:
+   - Purpose: Stops an active Kurtosis enclave.
+   - Options:
+      - `-k`: (Optional) Path to `kurtosis` executable. Defaults to `kurtosis`.
+      - `-n`: (Required) Enclave name.
+   - Example:
+     ```
+     go run emulate_network.go stop -k=/path/to/kurtosis -n=enclaveName
+     ```
+
+4. **help**:
+   - Purpose: Display a summary of available commands and their options.
+   - Example:
+     ```
+     go run emulate_network.go help
+     ```
+
+## Known issues
+### Kurtosis errors on network start
+Sometimes errors may stop Kurtosis from starting a new enclave. 
+1. Make sure you have no valuable containers up and running in enclaves or docker
+2. To clean up Kurtosis call `kurtosis clean -a`
+3. To clean up docker run `docker rm -vf $(docker ps -aq)`
+
+
+## Running in Docker in Docker
+See this note for refrence here

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -51,7 +51,6 @@ To run script `cd` into this (`./scripts`) folder.
       - `-a`: (Optional) Additional builder arguments.
       - `-s`: (Optional) Max steps (integer). Default `-1` for "unlimited".
       - `-k`: (Optional) Path to `kurtosis` executable. Defaults to `kurtosis`.
-      - `-c`: (Required) Kurtosis network config path to *ethereum-package* repo.
    - Example:
      ```
      go run emulate_network.go run -t=imageTag -a=imageArgs -n=enclaveName -k=/path/to/kurtosis
@@ -76,7 +75,7 @@ To run script `cd` into this (`./scripts`) folder.
 
 ## Known issues
 ### Kurtosis errors on network start
-Sometimes errors may stop Kurtosis from starting a new enclave. 
+In case of system resource related errors or on windows docker restore after sleep Kurtosis may have trouble starting a new enclave. 
 1. Make sure you have no valuable containers up and running in enclaves or docker
 2. To clean up Kurtosis call `kurtosis clean -a`
 3. To clean up docker run `docker rm -vf $(docker ps -aq)`


### PR DESCRIPTION
Allows image building, kurtosis ethereum-package starting and stopping using generated image.

## 📝 Summary

Created a Go script that follows the following API and is expected to exist in `./scripts` inside `builder` repo:

## Main features:

1. Runs on Windows and Linux using Go run
2. Does progressive command log printing
3. Allows to set ImageTag and provide ImageArgs when building starting the network

Example commands:

1. build ../ repo into docker image `go run emulate_network.go build`
2. run network and see deployment progress `go run emulate_network.go run -n=enclaveName -k="C:/Users/olegj/kurtosis.exe”`
3. stop network `go run emulate_network.go stop -n=enclaveName -k="C:/Users/olegj/kurtosis.exe”`

## 📚 References

Manual for detailed use args is provided in the readme file.

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
