### PR TITLE
Set dev builder image tag as `dev`

### DIFF
--- a/scripts/kurtosis/network_params.json
+++ b/scripts/kurtosis/network_params.json
@@ -22,7 +22,7 @@
         },
         {
             "el_client_type": "REPLACE_WITH_BUILDER",
-            "el_client_image": "flashbots/builder:1.13.2.4844.dev5-4d161de",
+            "el_client_image": "flashbots/builder:dev",
             "el_client_log_level": "",
             "cl_client_type": "lighthouse",
             "cl_client_image": "sigp/lighthouse:v4.5.0",


### PR DESCRIPTION
To avoid confusion change the tag to the same as default in go script